### PR TITLE
feat: adding object url checks

### DIFF
--- a/packages/storage/__tests__/providers/s3/utils/client/s3Data/abortMutipartUpload.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/s3Data/abortMutipartUpload.test.ts
@@ -1,0 +1,93 @@
+import { HttpResponse } from '@aws-amplify/core/internals/aws-client-utils';
+
+import { s3TransferHandler } from '../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch';
+import { abortMultipartUpload } from '../../../../../../src/providers/s3/utils/client/s3data';
+import { validateObjectUrl } from '../../../../../../src/providers/s3/utils/validateObjectUrl';
+import {
+	DEFAULT_RESPONSE_HEADERS,
+	defaultConfig,
+	expectedMetadata,
+} from '../S3/cases/shared';
+import { IntegrityError } from '../../../../../../src/errors/IntegrityError';
+
+jest.mock('../../../../../../src/providers/s3/utils/validateObjectUrl');
+jest.mock(
+	'../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch',
+);
+
+const mockS3TransferHandler = s3TransferHandler as jest.Mock;
+const mockBinaryResponse = ({
+	status,
+	headers,
+	body,
+}: {
+	status: number;
+	headers: Record<string, string>;
+	body: string;
+}): HttpResponse => {
+	const responseBody = {
+		json: async (): Promise<any> => {
+			throw new Error(
+				'Parsing response to JSON is not implemented. Please use response.text() instead.',
+			);
+		},
+		blob: async () => new Blob([body], { type: 'plain/text' }),
+		text: async () => body,
+	} as HttpResponse['body'];
+
+	return {
+		statusCode: status,
+		headers,
+		body: responseBody,
+	} as any;
+};
+
+const abortMultipartUploadSuccessResponse = {
+	status: 200,
+	headers: {
+		...DEFAULT_RESPONSE_HEADERS,
+		'x-amz-version-id': 'versionId',
+		etag: 'etag',
+	},
+	body: '',
+};
+
+describe('serializeAbortMultipartUploadRequest', () => {
+	const mockIsValidObjectUrl = jest.mocked(validateObjectUrl);
+	beforeEach(() => {
+		mockS3TransferHandler.mockReset();
+	});
+
+	it('should pass when objectUrl is durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(abortMultipartUploadSuccessResponse as any),
+		);
+		const output = await abortMultipartUpload(defaultConfig, {
+			Bucket: 'bucket',
+			Key: 'key',
+			UploadId: 'upload-id',
+		});
+		expect(output).toEqual({
+			$metadata: expect.objectContaining(expectedMetadata),
+		});
+	});
+
+	it('should fail when objectUrl is NOT durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(abortMultipartUploadSuccessResponse as any),
+		);
+		const integrityError = new IntegrityError();
+		mockIsValidObjectUrl.mockImplementationOnce(() => {
+			throw integrityError;
+		});
+		expect(
+			abortMultipartUpload(defaultConfig, {
+				Bucket: 'bucket',
+				Key: 'key',
+				UploadId: 'upload-id',
+			}),
+		).rejects.toThrow(integrityError);
+	});
+});

--- a/packages/storage/__tests__/providers/s3/utils/client/s3Data/deleteObject.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/s3Data/deleteObject.test.ts
@@ -1,0 +1,92 @@
+import { HttpResponse } from '@aws-amplify/core/internals/aws-client-utils';
+
+import { s3TransferHandler } from '../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch';
+import { deleteObject } from '../../../../../../src/providers/s3/utils/client/s3data';
+import { validateObjectUrl } from '../../../../../../src/providers/s3/utils/validateObjectUrl';
+import {
+	DEFAULT_RESPONSE_HEADERS,
+	defaultConfig,
+	expectedMetadata,
+} from '../S3/cases/shared';
+import { IntegrityError } from '../../../../../../src/errors/IntegrityError';
+
+jest.mock('../../../../../../src/providers/s3/utils/validateObjectUrl');
+jest.mock(
+	'../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch',
+);
+
+const mockS3TransferHandler = s3TransferHandler as jest.Mock;
+const mockBinaryResponse = ({
+	status,
+	headers,
+	body,
+}: {
+	status: number;
+	headers: Record<string, string>;
+	body: string;
+}): HttpResponse => {
+	const responseBody = {
+		json: async (): Promise<any> => {
+			throw new Error(
+				'Parsing response to JSON is not implemented. Please use response.text() instead.',
+			);
+		},
+		blob: async () => new Blob([body], { type: 'plain/text' }),
+		text: async () => body,
+	} as HttpResponse['body'];
+
+	return {
+		statusCode: status,
+		headers,
+		body: responseBody,
+	} as any;
+};
+
+const deleteObjectSuccessResponse = {
+	status: 200,
+	headers: {
+		...DEFAULT_RESPONSE_HEADERS,
+		'x-amz-version-id': 'versionId',
+		etag: 'etag',
+	},
+	body: '',
+};
+
+describe('serializeDeleteObjectRequest', () => {
+	const mockIsValidObjectUrl = jest.mocked(validateObjectUrl);
+	beforeEach(() => {
+		mockS3TransferHandler.mockReset();
+	});
+
+	it('should pass when objectUrl is durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(deleteObjectSuccessResponse as any),
+		);
+		const output = await deleteObject(defaultConfig, {
+			Bucket: 'bucket',
+			Key: 'key',
+		});
+		expect(output).toEqual({
+			$metadata: expect.objectContaining(expectedMetadata),
+			VersionId: 'versionId',
+		});
+	});
+
+	it('should fail when objectUrl is NOT durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(deleteObjectSuccessResponse as any),
+		);
+		const integrityError = new IntegrityError();
+		mockIsValidObjectUrl.mockImplementationOnce(() => {
+			throw integrityError;
+		});
+		expect(
+			deleteObject(defaultConfig, {
+				Bucket: 'bucket',
+				Key: 'key',
+			}),
+		).rejects.toThrow(integrityError);
+	});
+});

--- a/packages/storage/__tests__/providers/s3/utils/client/s3Data/getObject.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/s3Data/getObject.test.ts
@@ -1,0 +1,98 @@
+import { HttpResponse } from '@aws-amplify/core/internals/aws-client-utils';
+
+import { s3TransferHandler } from '../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch';
+import { getObject } from '../../../../../../src/providers/s3/utils/client/s3data';
+import { validateObjectUrl } from '../../../../../../src/providers/s3/utils/validateObjectUrl';
+import {
+	DEFAULT_RESPONSE_HEADERS,
+	defaultConfig,
+	expectedMetadata,
+} from '../S3/cases/shared';
+import { IntegrityError } from '../../../../../../src/errors/IntegrityError';
+
+jest.mock('../../../../../../src/providers/s3/utils/validateObjectUrl');
+jest.mock(
+	'../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch',
+);
+
+const mockS3TransferHandler = s3TransferHandler as jest.Mock;
+const mockBinaryResponse = ({
+	status,
+	headers,
+	body,
+}: {
+	status: number;
+	headers: Record<string, string>;
+	body: string;
+}): HttpResponse => {
+	const responseBody = {
+		json: async (): Promise<any> => {
+			throw new Error(
+				'Parsing response to JSON is not implemented. Please use response.text() instead.',
+			);
+		},
+		blob: async () => new Blob([body], { type: 'plain/text' }),
+		text: async () => body,
+	} as HttpResponse['body'];
+
+	return {
+		statusCode: status,
+		headers,
+		body: responseBody,
+	} as any;
+};
+
+const getObjectSuccessResponse = {
+	status: 200,
+	headers: {
+		...DEFAULT_RESPONSE_HEADERS,
+		'x-amz-version-id': 'versionId',
+		etag: 'etag',
+	},
+	body: '',
+};
+
+describe('serializeGetObjectRequest', () => {
+	const mockIsValidObjectUrl = jest.mocked(validateObjectUrl);
+	beforeEach(() => {
+		mockS3TransferHandler.mockReset();
+	});
+
+	it('should pass when objectUrl is durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(getObjectSuccessResponse as any),
+		);
+		const output = await getObject(defaultConfig, {
+			Bucket: 'bucket',
+			Key: 'key',
+		});
+		expect(output).toEqual({
+			$metadata: expect.objectContaining(expectedMetadata),
+			ETag: 'etag',
+			VersionId: 'versionId',
+			Body: expect.objectContaining({
+				text: expect.any(Function),
+				blob: expect.any(Function),
+				json: expect.any(Function),
+			}),
+		});
+	});
+
+	it('should fail when objectUrl is NOT durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(getObjectSuccessResponse as any),
+		);
+		const integrityError = new IntegrityError();
+		mockIsValidObjectUrl.mockImplementationOnce(() => {
+			throw integrityError;
+		});
+		expect(
+			getObject(defaultConfig, {
+				Bucket: 'bucket',
+				Key: 'key',
+			}),
+		).rejects.toThrow(integrityError);
+	});
+});

--- a/packages/storage/__tests__/providers/s3/utils/client/s3Data/headObject.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/s3Data/headObject.test.ts
@@ -1,0 +1,93 @@
+import { HttpResponse } from '@aws-amplify/core/internals/aws-client-utils';
+
+import { s3TransferHandler } from '../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch';
+import { headObject } from '../../../../../../src/providers/s3/utils/client/s3data';
+import { validateObjectUrl } from '../../../../../../src/providers/s3/utils/validateObjectUrl';
+import {
+	DEFAULT_RESPONSE_HEADERS,
+	defaultConfig,
+	expectedMetadata,
+} from '../S3/cases/shared';
+import { IntegrityError } from '../../../../../../src/errors/IntegrityError';
+
+jest.mock('../../../../../../src/providers/s3/utils/validateObjectUrl');
+jest.mock(
+	'../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch',
+);
+
+const mockS3TransferHandler = s3TransferHandler as jest.Mock;
+const mockBinaryResponse = ({
+	status,
+	headers,
+	body,
+}: {
+	status: number;
+	headers: Record<string, string>;
+	body: string;
+}): HttpResponse => {
+	const responseBody = {
+		json: async (): Promise<any> => {
+			throw new Error(
+				'Parsing response to JSON is not implemented. Please use response.text() instead.',
+			);
+		},
+		blob: async () => new Blob([body], { type: 'plain/text' }),
+		text: async () => body,
+	} as HttpResponse['body'];
+
+	return {
+		statusCode: status,
+		headers,
+		body: responseBody,
+	} as any;
+};
+
+const headObjectSuccessResponse = {
+	status: 200,
+	headers: {
+		...DEFAULT_RESPONSE_HEADERS,
+		'x-amz-version-id': 'versionId',
+		etag: 'etag',
+	},
+	body: '',
+};
+
+describe('serializeHeadObjectRequest', () => {
+	const mockIsValidObjectUrl = jest.mocked(validateObjectUrl);
+	beforeEach(() => {
+		mockS3TransferHandler.mockReset();
+	});
+
+	it('should pass when objectUrl is durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(headObjectSuccessResponse as any),
+		);
+		const output = await headObject(defaultConfig, {
+			Bucket: 'bucket',
+			Key: 'key',
+		});
+		expect(output).toEqual({
+			$metadata: expect.objectContaining(expectedMetadata),
+			VersionId: 'versionId',
+			ETag: 'etag',
+		});
+	});
+
+	it('should fail when objectUrl is NOT durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(headObjectSuccessResponse as any),
+		);
+		const integrityError = new IntegrityError();
+		mockIsValidObjectUrl.mockImplementationOnce(() => {
+			throw integrityError;
+		});
+		expect(
+			headObject(defaultConfig, {
+				Bucket: 'bucket',
+				Key: 'key',
+			}),
+		).rejects.toThrow(integrityError);
+	});
+});

--- a/packages/storage/__tests__/providers/s3/utils/client/s3Data/uploadPart.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/s3Data/uploadPart.test.ts
@@ -1,0 +1,96 @@
+import { HttpResponse } from '@aws-amplify/core/internals/aws-client-utils';
+
+import { s3TransferHandler } from '../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch';
+import { uploadPart } from '../../../../../../src/providers/s3/utils/client/s3data';
+import { validateObjectUrl } from '../../../../../../src/providers/s3/utils/validateObjectUrl';
+import {
+	DEFAULT_RESPONSE_HEADERS,
+	defaultConfig,
+	expectedMetadata,
+} from '../S3/cases/shared';
+import { IntegrityError } from '../../../../../../src/errors/IntegrityError';
+
+jest.mock('../../../../../../src/providers/s3/utils/validateObjectUrl');
+jest.mock(
+	'../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch',
+);
+
+const mockS3TransferHandler = s3TransferHandler as jest.Mock;
+const mockBinaryResponse = ({
+	status,
+	headers,
+	body,
+}: {
+	status: number;
+	headers: Record<string, string>;
+	body: string;
+}): HttpResponse => {
+	const responseBody = {
+		json: async (): Promise<any> => {
+			throw new Error(
+				'Parsing response to JSON is not implemented. Please use response.text() instead.',
+			);
+		},
+		blob: async () => new Blob([body], { type: 'plain/text' }),
+		text: async () => body,
+	} as HttpResponse['body'];
+
+	return {
+		statusCode: status,
+		headers,
+		body: responseBody,
+	} as any;
+};
+
+const uploadPartSuccessResponse = {
+	status: 200,
+	headers: {
+		...DEFAULT_RESPONSE_HEADERS,
+		'x-amz-version-id': 'versionId',
+		etag: 'etag',
+	},
+	body: '',
+};
+
+describe('serializeUploadPartRequest', () => {
+	const mockIsValidObjectUrl = jest.mocked(validateObjectUrl);
+	beforeEach(() => {
+		mockS3TransferHandler.mockReset();
+	});
+
+	it('should pass when objectUrl is durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(uploadPartSuccessResponse as any),
+		);
+		const output = await uploadPart(defaultConfig, {
+			Bucket: 'bucket',
+			Key: 'key',
+			PartNumber: 1,
+			UploadId: 'uploadId',
+		});
+		expect(output).toEqual({
+			$metadata: expect.objectContaining(expectedMetadata),
+			ETag: 'etag',
+		});
+	});
+
+	it('should fail when objectUrl is NOT durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(uploadPartSuccessResponse as any),
+		);
+		const integrityError = new IntegrityError();
+		mockIsValidObjectUrl.mockImplementationOnce(() => {
+			throw integrityError;
+		});
+		expect(
+			uploadPart(defaultConfig, {
+				Bucket: 'bucket',
+				Key: 'key',
+				PartNumber: 1,
+				UploadId: 'uploadId',
+			}),
+		).rejects.toThrow(integrityError);
+	});
+});

--- a/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
@@ -21,6 +21,7 @@ import {
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
+import { validateObjectUrl } from '../../validateObjectUrl';
 
 import type { AbortMultipartUploadCommandInput } from './types';
 import { defaultConfig } from './base';
@@ -43,6 +44,11 @@ const abortMultipartUploadSerializer = (
 	url.search = new AmplifyUrlSearchParams({
 		uploadId: input.UploadId,
 	}).toString();
+	validateObjectUrl({
+		bucketName: input.Bucket,
+		key: input.Key,
+		objectURL: url,
+	});
 
 	return {
 		method: 'DELETE',

--- a/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
@@ -19,6 +19,7 @@ import {
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
+import { validateObjectUrl } from '../../validateObjectUrl';
 
 import type {
 	DeleteObjectCommandInput,
@@ -40,6 +41,11 @@ const deleteObjectSerializer = (
 	const url = new AmplifyUrl(endpoint.url.toString());
 	validateS3RequiredParameter(!!input.Key, 'Key');
 	url.pathname = serializePathnameObjectKey(url, input.Key);
+	validateObjectUrl({
+		bucketName: input.Bucket,
+		key: input.Key,
+		objectURL: url,
+	});
 
 	return {
 		method: 'DELETE',

--- a/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
@@ -27,6 +27,7 @@ import {
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
+import { validateObjectUrl } from '../../validateObjectUrl';
 
 import { S3EndpointResolverOptions, defaultConfig } from './base';
 import type {
@@ -55,6 +56,11 @@ const getObjectSerializer = async (
 	const url = new AmplifyUrl(endpoint.url.toString());
 	validateS3RequiredParameter(!!input.Key, 'Key');
 	url.pathname = serializePathnameObjectKey(url, input.Key);
+	validateObjectUrl({
+		bucketName: input.Bucket,
+		key: input.Key,
+		objectURL: url,
+	});
 
 	return {
 		method: 'GET',

--- a/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
@@ -21,6 +21,7 @@ import {
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
+import { validateObjectUrl } from '../../validateObjectUrl';
 
 import { defaultConfig } from './base';
 import type { HeadObjectCommandInput, HeadObjectCommandOutput } from './types';
@@ -45,6 +46,11 @@ const headObjectSerializer = async (
 	const url = new AmplifyUrl(endpoint.url.toString());
 	validateS3RequiredParameter(!!input.Key, 'Key');
 	url.pathname = serializePathnameObjectKey(url, input.Key);
+	validateObjectUrl({
+		bucketName: input.Bucket,
+		key: input.Key,
+		objectURL: url,
+	});
 
 	return {
 		method: 'HEAD',

--- a/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
@@ -22,6 +22,7 @@ import {
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
+import { validateObjectUrl } from '../../validateObjectUrl';
 
 import { defaultConfig } from './base';
 import type { UploadPartCommandInput, UploadPartCommandOutput } from './types';
@@ -62,6 +63,11 @@ const uploadPartSerializer = async (
 		partNumber: input.PartNumber + '',
 		uploadId: input.UploadId,
 	}).toString();
+	validateObjectUrl({
+		bucketName: input.Bucket,
+		key: input.Key,
+		objectURL: url,
+	});
 
 	return {
 		method: 'PUT',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Add `validateObjectUrl` function to:
  - abortMultipartUpload
  - deleteObject
  - uploadPart
  - getObject
  - headObject

#### Description of how you validated changes
- Executed environment with `yarn dev`
- Executed unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
